### PR TITLE
fix: Bulk export - DebtPositionTypeOrg code misinterpretation

### DIFF
--- a/src/main/java/it/gov/pagopa/pu/sil/endpoint/PuForOrganizationPaymentsEndpoint.java
+++ b/src/main/java/it/gov/pagopa/pu/sil/endpoint/PuForOrganizationPaymentsEndpoint.java
@@ -375,8 +375,8 @@ public class PuForOrganizationPaymentsEndpoint {
     OffsetDateTime to = optRequest.flatMap(r -> Optional.ofNullable(r.getDateTo()))
       .map(x -> x.toGregorianCalendar().toZonedDateTime().toOffsetDateTime()).orElse(null);
 
-    Long debtPositionTypeOrgId = optRequest.flatMap(r -> Optional.ofNullable(r.getIdentificativoTipoDovuto()))
-      .map(Long::valueOf).orElse(null);
+    String debtPositionTypeOrgCode = optRequest.flatMap(r -> Optional.ofNullable(r.getIdentificativoTipoDovuto()))
+      .orElse(null);
 
     return registryLogger.execute(
       contextData,
@@ -389,7 +389,7 @@ public class PuForOrganizationPaymentsEndpoint {
           fileVersion,
           from,
           to,
-          debtPositionTypeOrgId
+          debtPositionTypeOrgCode
         );
         PaaSILPrenotaExportFlussoRisposta response = new PaaSILPrenotaExportFlussoRisposta();
         response.setRequestToken(String.valueOf(result));

--- a/src/main/java/it/gov/pagopa/pu/sil/service/exportfile/PaaSILPrenotaExportFlussoService.java
+++ b/src/main/java/it/gov/pagopa/pu/sil/service/exportfile/PaaSILPrenotaExportFlussoService.java
@@ -37,7 +37,7 @@ public class PaaSILPrenotaExportFlussoService {
     String fileVersion,
     OffsetDateTime from,
     OffsetDateTime to,
-    Long debtPositionTypeOrgId) {
+    String debtPositionTypeOrgCode) {
 
     String clientId = Optional.ofNullable(userInfo).map(UserInfo::getUserId).orElse(null);
 
@@ -49,15 +49,15 @@ public class PaaSILPrenotaExportFlussoService {
     Long organizationId = AuthorizationService.getOrganizationIdFromUserInfo(userInfo, orgIpaCode);
 
     DebtPositionTypeOrg debtPositionTypeOrg = debtPositionService.getDebtPositionTypeOrgByOrgIdAndType(
-      organizationId, debtPositionTypeOrgId.toString(), accessToken);
+      organizationId, debtPositionTypeOrgCode, accessToken);
 
     if (debtPositionTypeOrg == null) {
-      throw new ExportFileServiceException(SilFaults.PAA_IDENTIFICATIVO_TIPO_DOVUTO_NON_VALIDO, "Tipo dovuto non valido: " + debtPositionTypeOrgId);
+      throw new ExportFileServiceException(SilFaults.PAA_IDENTIFICATIVO_TIPO_DOVUTO_NON_VALIDO, "Tipo dovuto non valido: " + debtPositionTypeOrgCode);
     } else if (Boolean.FALSE.equals(debtPositionTypeOrg.getFlagActive())) {
-      throw new ExportFileServiceException(SilFaults.PAA_IDENTIFICATIVO_TIPO_DOVUTO_NON_ABILITATO, "Tipo dovuto non abilitato: " + debtPositionTypeOrgId);
+      throw new ExportFileServiceException(SilFaults.PAA_IDENTIFICATIVO_TIPO_DOVUTO_NON_ABILITATO, "Tipo dovuto non abilitato: " + debtPositionTypeOrgCode);
     }
 
-    PaidExportFileRequestDTO requestDTO = mapToExportRequest(organizationId, fileVersion, from, to, debtPositionTypeOrgId);
+    PaidExportFileRequestDTO requestDTO = mapToExportRequest(organizationId, fileVersion, from, to, debtPositionTypeOrg.getDebtPositionTypeOrgId());
 
     Long exportFileId = exportFileService.createPaidExportFile(requestDTO, accessToken);
     log.debug("Export file created with ID: {}", exportFileId);

--- a/src/test/java/it/gov/pagopa/pu/sil/endpoint/PuForOrganizationPaymentsEndpointTest.java
+++ b/src/test/java/it/gov/pagopa/pu/sil/endpoint/PuForOrganizationPaymentsEndpointTest.java
@@ -373,7 +373,7 @@ class PuForOrganizationPaymentsEndpointTest {
   void givenValidRequestWhenPaaSILPrenotaExportFlussoThenResponseContainsExpectedToken() throws Exception {
     // Given
     PaaSILPrenotaExportFlusso request = podamFactory.manufacturePojo(PaaSILPrenotaExportFlusso.class);
-    request.setIdentificativoTipoDovuto("1");
+    request.setIdentificativoTipoDovuto("THAT_TYPE");
     IntestazionePPT intestazionePPT = podamFactory.manufacturePojo(IntestazionePPT.class);
     intestazionePPT.setCodIpaEnte(VALID_ORG_IPA_CODE);
     SoapHeaderElement header = TestUtils.createSoapHeaderElement(intestazionePPT, IntestazionePPT.class);
@@ -402,7 +402,7 @@ class PuForOrganizationPaymentsEndpointTest {
   void givenValidRequestWhenPaaSILPrenotaExportFlussoThrowsClientExceptionThenResponseContainsExpectedFaultCode() throws Exception {
     // Given
     PaaSILPrenotaExportFlusso request = podamFactory.manufacturePojo(PaaSILPrenotaExportFlusso.class);
-    request.setIdentificativoTipoDovuto("1");
+    request.setIdentificativoTipoDovuto("THAT_TYPE");
     IntestazionePPT intestazionePPT = podamFactory.manufacturePojo(IntestazionePPT.class);
     intestazionePPT.setCodIpaEnte(VALID_ORG_IPA_CODE);
     SoapHeaderElement header = TestUtils.createSoapHeaderElement(intestazionePPT, IntestazionePPT.class);
@@ -430,7 +430,7 @@ class PuForOrganizationPaymentsEndpointTest {
   void givenValidRequestWhenPaaSILPrenotaExportFlussoThrowsServiceExceptionThenResponseContainsExpectedFaultCode() throws Exception {
     // Given
     PaaSILPrenotaExportFlusso request = podamFactory.manufacturePojo(PaaSILPrenotaExportFlusso.class);
-    request.setIdentificativoTipoDovuto("1");
+    request.setIdentificativoTipoDovuto("THAT_TYPE");
     IntestazionePPT intestazionePPT = podamFactory.manufacturePojo(IntestazionePPT.class);
     intestazionePPT.setCodIpaEnte(VALID_ORG_IPA_CODE);
     SoapHeaderElement header = TestUtils.createSoapHeaderElement(intestazionePPT, IntestazionePPT.class);

--- a/src/test/java/it/gov/pagopa/pu/sil/service/exportfile/PaaSILPrenotaExportFlussoServiceTest.java
+++ b/src/test/java/it/gov/pagopa/pu/sil/service/exportfile/PaaSILPrenotaExportFlussoServiceTest.java
@@ -65,7 +65,7 @@ class PaaSILPrenotaExportFlussoServiceTest {
     String fileVersion = "1.0";
     OffsetDateTime from = OffsetDateTime.now();
     OffsetDateTime to = OffsetDateTime.now();
-    Long debtPositionTypeOrgId = 1L;
+    String debtPositionTypeOrgCode = "code";
 
     try (MockedStatic<AuthorizationService> authMock = mockStatic(AuthorizationService.class)) {
       authMock.when(() -> AuthorizationService.isAdminRole(eq(orgIpaCode), eq(userInfo))).thenReturn(false);
@@ -78,7 +78,7 @@ class PaaSILPrenotaExportFlussoServiceTest {
           fileVersion,
           from,
           to,
-          debtPositionTypeOrgId
+          debtPositionTypeOrgCode
         )
       );
       verifyNoInteractions(
@@ -97,7 +97,7 @@ class PaaSILPrenotaExportFlussoServiceTest {
     String fileVersion = "1.0";
     OffsetDateTime from = OffsetDateTime.now();
     OffsetDateTime to = OffsetDateTime.now();
-    Long debtPositionTypeOrgId = 1L;
+    String debtPositionTypeOrgCode = "code";
 
     try (MockedStatic<AuthorizationService> authMock = mockStatic(AuthorizationService.class)) {
       authMock.when(() -> AuthorizationService.isAdminRole(eq(orgIpaCode), eq(userInfo))).thenReturn(true);
@@ -118,7 +118,7 @@ class PaaSILPrenotaExportFlussoServiceTest {
         fileVersion,
         from,
         to,
-        debtPositionTypeOrgId
+        debtPositionTypeOrgCode
       );
 
       assertNotNull(result);
@@ -136,7 +136,7 @@ class PaaSILPrenotaExportFlussoServiceTest {
     String fileVersion = "1.0";
     OffsetDateTime from = OffsetDateTime.now();
     OffsetDateTime to = OffsetDateTime.now();
-    Long debtPositionTypeOrgId = 1L;
+    String debtPositionTypeOrgCode = "code";
 
     try (MockedStatic<AuthorizationService> authMock = mockStatic(AuthorizationService.class)) {
       authMock.when(() -> AuthorizationService.isAdminRole(eq(orgIpaCode), isNull())).thenReturn(true);
@@ -156,7 +156,7 @@ class PaaSILPrenotaExportFlussoServiceTest {
         fileVersion,
         from,
         to,
-        debtPositionTypeOrgId
+        debtPositionTypeOrgCode
       );
 
       assertNotNull(result);
@@ -175,7 +175,7 @@ class PaaSILPrenotaExportFlussoServiceTest {
     String fileVersion = "1.0";
     OffsetDateTime from = OffsetDateTime.now();
     OffsetDateTime to = OffsetDateTime.now();
-    Long debtPositionTypeOrgId = 1L;
+    String debtPositionTypeOrgCode = "code";
 
     try (MockedStatic<AuthorizationService> authMock = mockStatic(AuthorizationService.class)) {
       authMock.when(() -> AuthorizationService.isAdminRole(eq(orgIpaCode), eq(userInfo))).thenReturn(true);
@@ -192,7 +192,7 @@ class PaaSILPrenotaExportFlussoServiceTest {
           fileVersion,
           from,
           to,
-          debtPositionTypeOrgId
+          debtPositionTypeOrgCode
         )
       );
 
@@ -212,7 +212,7 @@ class PaaSILPrenotaExportFlussoServiceTest {
     String fileVersion = "1.0";
     OffsetDateTime from = OffsetDateTime.now();
     OffsetDateTime to = OffsetDateTime.now();
-    Long debtPositionTypeOrgId = 1L;
+    String debtPositionTypeOrgCode = "code";
 
     try (MockedStatic<AuthorizationService> authMock = mockStatic(AuthorizationService.class)) {
       authMock.when(() -> AuthorizationService.isAdminRole(eq(orgIpaCode), eq(userInfo))).thenReturn(true);
@@ -234,7 +234,7 @@ class PaaSILPrenotaExportFlussoServiceTest {
           fileVersion,
           from,
           to,
-          debtPositionTypeOrgId
+          debtPositionTypeOrgCode
         )
       );
 


### PR DESCRIPTION
#### Description
The purpose of the modification is to fix the misinterpretation of the request's ‘identificativoTipoDovuto’ field within the SOAP action PaaSILPrenotaExportFlusso
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
<!--- Describe your changes in detail -->

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- Pre-Deploy Test
  - [x] Unit
  - [ ] Integration (Narrow)
- Post-Deploy Test
  - [ ] Isolated Microservice
  - [ ] Broader Integration
  - [ ] Acceptance
  - [ ] Performance & Load

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] PATCH - Bug fix (backwards compatible bug fixes)
- [ ] MINOR - New feature (add functionality in a backwards compatible manner)
- [ ] MAJOR - Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] CHORE - Minor Change (fix or feature that don't impact the functionality e.g. Documentation or lint configuration)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
