### PR TITLE
fix: P4ADEV-3734 fix null-pointer exception in send-notification pu-sil API

### DIFF
--- a/src/main/java/it/gov/pagopa/pu/sil/service/notification/SendNotificationRetrieverServiceImpl.java
+++ b/src/main/java/it/gov/pagopa/pu/sil/service/notification/SendNotificationRetrieverServiceImpl.java
@@ -57,8 +57,11 @@ public class SendNotificationRetrieverServiceImpl implements SendNotificationRet
   }
 
   private static void validateSendNotificationOrganization(Long organizationId, SendNotificationDTO sendNotification) {
-    if(!sendNotification.getOrganizationId().equals(organizationId)){
-      log.info("Requested Notification for organization {}, but the sendNotificationId ({}) is related to organizationId {}", organizationId, sendNotification, sendNotification.getOrganizationId());
+    if(sendNotification == null || !sendNotification.getOrganizationId().equals(organizationId)){
+      String errorMessage = sendNotification == null ?
+        "Requested Notification for organization %s, but requested sendNotification is not found".formatted(organizationId) :
+        "Requested Notification for organization %s, but the sendNotificationId (%s) is related to organizationId %s".formatted(organizationId, sendNotification, sendNotification.getOrganizationId());
+      log.info(errorMessage);
       throw new IllegalArgumentException("SendNotification not found");
     }
   }

--- a/src/test/java/it/gov/pagopa/pu/sil/service/notification/SendNotificationRetrieverServiceImplTest.java
+++ b/src/test/java/it/gov/pagopa/pu/sil/service/notification/SendNotificationRetrieverServiceImplTest.java
@@ -118,6 +118,23 @@ class SendNotificationRetrieverServiceImplTest {
   }
 
   @Test
+  void givenNotFoundNotificationWhenDeleteSendNotificationThenIllegalArgumentException() {
+    // Given
+    Long organizationId = 1L;
+    UserInfo loggedUser = AuthorizationServiceTest.buildAdminUser(organizationId, "ORGFC", "orgIpaCode");
+    String accessToken = "TOKEN";
+    String sendNotificationId = "sendNotificationId";
+
+    Mockito.when(
+      notificationServiceMock.getSendNotification(sendNotificationId, accessToken)
+    ).thenReturn(null);
+
+    // When,Then
+    Assertions.assertThrows(IllegalArgumentException.class, () ->
+      sendNotificationRetrieverService.deleteSendNotification(sendNotificationId, organizationId, loggedUser, accessToken));
+  }
+
+  @Test
   void givenInvalidUserWhenDeleteSendNotificationThenAuthorizationDeniedException() {
     // Given
     Long organizationId = 1L;
@@ -163,6 +180,24 @@ class SendNotificationRetrieverServiceImplTest {
 
     Mockito.when(notificationServiceMock.getSendNotification(sendNotificationId, accessToken)).thenReturn(
       expectedResult);
+
+    // When, Then
+    Assertions.assertThrows(IllegalArgumentException.class, () ->
+      sendNotificationRetrieverService.getSendNotification(sendNotificationId, organizationId, loggedUser, accessToken)
+    );
+  }
+
+  @Test
+  void givenNotFoundNotificationWhenGetSendNotificationThenThrowIllegalArgumentException() {
+    // Given
+    Long organizationId = 1L;
+    UserInfo loggedUser = AuthorizationServiceTest.buildAdminUser(organizationId, "ORGFC", "orgIpaCode");
+    String accessToken = "TOKEN";
+    String sendNotificationId = "sendNotificationId";
+
+    Mockito.when(
+      notificationServiceMock.getSendNotification(sendNotificationId, accessToken)
+    ).thenReturn(null);
 
     // When, Then
     Assertions.assertThrows(IllegalArgumentException.class, () ->
@@ -239,6 +274,33 @@ class SendNotificationRetrieverServiceImplTest {
         accessToken
       )
     ).thenReturn(sendNotificationForDifferentOrg);
+
+    // When, Then
+    Assertions.assertThrows(
+      IllegalArgumentException.class,
+      () -> sendNotificationRetrieverService.getLegalFacts(
+        sendNotificationId,
+        organizationId,
+        validUser,
+        accessToken
+      )
+    );
+  }
+
+  @Test
+  void givenNotFoundNotificationWhenGetLegalFactsThenThrowIllegalArgumentException() {
+    // Given
+    Long organizationId = 1L;
+    UserInfo validUser = AuthorizationServiceTest.buildAdminUser(organizationId, "ORGFC", "orgIpaCode");
+    String accessToken = "TOKEN";
+    String sendNotificationId = "SEND_NOTIFICATION_ID";
+
+    Mockito.when(
+      notificationServiceMock.getSendNotification(
+        sendNotificationId,
+        accessToken
+      )
+    ).thenReturn(null);
 
     // When, Then
     Assertions.assertThrows(
@@ -332,6 +394,35 @@ class SendNotificationRetrieverServiceImplTest {
         accessToken
       )
     ).thenReturn(sendNotificationForDifferentOrg);
+
+    // When, Then
+    Assertions.assertThrows(
+      IllegalArgumentException.class,
+      () -> sendNotificationRetrieverService.getLegalFactDownloadMetadata(
+        sendNotificationId,
+        legalFactId,
+        organizationId,
+        validUser,
+        accessToken
+      )
+    );
+  }
+
+  @Test
+  void givenNotFoundNotificationWhenGetLegalFactDownloadMetadataThenThrowIllegalArgumentException() {
+    // Given
+    Long organizationId = 1L;
+    UserInfo validUser = AuthorizationServiceTest.buildAdminUser(organizationId, "ORGFC", "orgIpaCode");
+    String accessToken = "TOKEN";
+    String sendNotificationId = "SEND_NOTIFICATION_ID";
+    String legalFactId = "LEGAL_FACT_ID";
+
+    Mockito.when(
+      notificationServiceMock.getSendNotification(
+        sendNotificationId,
+        accessToken
+      )
+    ).thenReturn(null);
 
     // When, Then
     Assertions.assertThrows(


### PR DESCRIPTION
#### Description
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
Fixed null-pointer exception in validateSendNotificationOrganization when sendNotification == null

#### List of Changes
<!--- Describe your changes in detail -->

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- Pre-Deploy Test
  - [x] Unit
  - [ ] Integration (Narrow)
- Post-Deploy Test
  - [ ] Isolated Microservice
  - [ ] Broader Integration
  - [ ] Acceptance
  - [ ] Performance & Load

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] PATCH - Bug fix (backwards compatible bug fixes)
- [ ] MINOR - New feature (add functionality in a backwards compatible manner)
- [ ] MAJOR - Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] CHORE - Minor Change (fix or feature that don't impact the functionality e.g. Documentation or lint configuration)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
